### PR TITLE
Breadth-First Search

### DIFF
--- a/modules/Player.py
+++ b/modules/Player.py
@@ -163,7 +163,7 @@ class Player(BasePlayer):
         # neighbouring nodes of the current node before we proceed.
         queue = deque([start])
         # Start looping through the map from the current node.
-        while True:
+        while queue:
             # Identify the currently assessed node
             current = queue.pop()
             # If the current node is the target node, we are done we need to backtrack to the start to create the path


### PR DESCRIPTION
Implementation of a quick breadth first search algorithm to find the path that requires the fewest turns to arrive. Closes #14 Move to Function.

### How it works:
The algorithm intialises the current position, and two containers:
1. previous dictionary
2. visited dictionary
Since we are doing a breadth first search, each node will necessarily have only one previous node, so a dictionary mapping is fine.
The visited dictionary maps each node in the map with a boolean, True if visited in the algorithm, False otherwise.

The current node is first set to the starting node, will be declared as visited.
Then with an infinite while loop, loop through the neighbours of the current node.
If any of the neighbours have not been visited, add that to the queue. Logic of the queue: it is a first in, first out container, which means we are doing a breadth, not a depth search.
At each neighbour node, add the current node to the previous dictionary mapping. this way, the current node can be updated.
This continues until one of the neighbours is the target location, which stops the algorithm, and then backtracks through the previous mappings to reach the starting node.